### PR TITLE
feat: crédito de autoría en el footer

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -90,6 +90,17 @@ const Footer = () => {
           <p className="text-sm text-gray-400">
             © {currentYear} GoGestia. Todos los derechos reservados.
           </p>
+          <p className="text-sm text-gray-400">
+            Diseñado y Desarrollado por{' '}
+            <a
+              href="https://www.alexalvarez.dev"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-agency-dark transition-colors"
+            >
+              alexalvarez.dev
+            </a>
+          </p>
           <div className="flex space-x-6">
             <a
               href="https://www.linkedin.com/company/gogestia"


### PR DESCRIPTION
Añade en el footer la línea **Diseñado y Desarrollado por alexalvarez.dev**, donde `alexalvarez.dev` enlaza a https://www.alexalvarez.dev (`target="_blank"`, `rel="noopener noreferrer"`).

El texto hereda el color y el tamaño del resto del pie, así que no cambia el diseño más allá de la línea nueva.

Parte de una unificación del mismo crédito en todas las webs del portfolio.